### PR TITLE
Add functionality to parse JSON secret values

### DIFF
--- a/confmap/provider/secretsmanagerprovider/README.md
+++ b/confmap/provider/secretsmanagerprovider/README.md
@@ -5,6 +5,7 @@ Collector the ability to read data stored in AWS Secrets Manager.
 ## How it works
 - Just use the placeholders with the following pattern `${secretsmanager:<arn or name>}`
 - Make sure you have the `secretsmanager:GetSecretValue` in the OTEL Collector Role
+- If the secret contains multiple key/value pairs then it's possible to extract a value by passing a key at the end of the placeholder, delimited by a `#`: `${secretsmanager:<arn or name>#mykey}`
 
 Prerequisites:
 - Need to setup access keys from IAM console (aws_access_key_id and aws_secret_access_key) with permission to access Amazon Secrets Manager


### PR DESCRIPTION
**Description:**
Added functionality to parse JSON secret values returned from AWS Secrets Manager in the secretsmanager confmap. Supports passing a key as part of the uri, delimited by the `#` symbol.
Existing simple string values are still supported.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32143

**Testing:**
A single additional test has been added to test a simple key/value JSON string returned from the AWS Secrets Manager endpoint.

**Documentation:**
Brief documentation added to explain how to use the functionality in the README